### PR TITLE
Update tests config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,pypy,pypy3
+envlist=py26,py27,py33,py34,py35,pypy,pypy3,lint
 [testenv]
 deps=nose
 commands=nosetests
+[testenv:lint]
+deps=pylint
+commands=pylint --rcfile=.pylintrc --reports=n --output-format=colorized sortedcontainers

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35
+envlist=py26,py27,py33,py34,py35,pypy,pypy3
 [testenv]
 deps=nose
 commands=nosetests


### PR DESCRIPTION
This pull-request adds a lint environment to the tox config. It only targets the sortedcontainers sub directory.
The tests directory yields lots of lint errors. This may be a signal that these need reviewing.

I also included pypy and pypy3 in the tox environment list. All tests pass.
Use `--skip-missing-interpreters` if you don't have these available.

The travis configuration was changed to use container environments.
See: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments