### PR TITLE
Test on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,24 @@
 sudo: false
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
-  - "pypy3"
-install: true
-script:  nosetests -v
+install: pip install tox
+script: tox
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
+    - python: 3.6
+      env: TOXENV=lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,pypy,pypy3,lint
+envlist=py26,py27,py33,py34,py35,py36,pypy,pypy3,lint
 [testenv]
 deps=nose
 commands=nosetests


### PR DESCRIPTION
This pull-request:

- adds Python 3.6 to the list of python versions tested
- changes travis config to use tox to run the tests