### PR TITLE
remove duplicate `d.clear()` entry from docs

### DIFF
--- a/docs/sorteddict.rst
+++ b/docs/sorteddict.rst
@@ -115,7 +115,7 @@ best way to get started.
 
    .. method:: d.clear()
 
-      Remove all elements from the dictionary.
+      Remove all elements from the sorted dictionary.
 
    .. method:: d.copy()
 
@@ -225,10 +225,6 @@ best way to get started.
       the :class:`ValuesView` is indexable (e.g., ``d.values()[5]``).
 
       :rtype: :class:`list` or :class:`ValuesView`
-
-   .. method:: d.clear()
-
-      Remove all the elements from the sorted dictionary.
 
    .. method:: d.has_key(key)
 

--- a/sortedcontainers/sorteddict.py
+++ b/sortedcontainers/sorteddict.py
@@ -97,14 +97,14 @@ class SortedDict(dict):
         identifiers; the others work with any valid keys.
 
         """
-        # pylint: disable=super-init-not-called, redefined-variable-type
-        if len(args) > 0 and (args[0] is None or callable(args[0])):
+        # pylint: disable=super-init-not-called
+        if args and (args[0] is None or callable(args[0])):
             self._key = args[0]
             args = args[1:]
         else:
             self._key = None
 
-        if len(args) > 0 and isinstance(args[0], int):
+        if args and isinstance(args[0], int):
             self._load = args[0]
             args = args[1:]
         else:
@@ -298,7 +298,7 @@ class SortedDict(dict):
         If the dictionary is empty, calling `popitem` raises a
         KeyError`.
         """
-        if not len(self):
+        if not self:
             raise KeyError('popitem(): dictionary is empty')
 
         key = self._list_pop(-1 if last else 0)
@@ -327,10 +327,9 @@ class SortedDict(dict):
         """
         if key in self:
             return self[key]
-        else:
-            self._setitem(key, default)
-            self._list_add(key)
-            return default
+        self._setitem(key, default)
+        self._list_add(key)
+        return default
 
     def update(self, *args, **kwargs):
         """
@@ -342,12 +341,12 @@ class SortedDict(dict):
         keyword arguments are specified, the dictionary is then updated with
         those key/value pairs: ``d.update(red=1, blue=2)``.
         """
-        if not len(self):
+        if not self:
             self._dict_update(*args, **kwargs)
             self._list_update(self._iter())
             return
 
-        if len(kwargs) == 0 and len(args) == 1 and isinstance(args[0], dict):
+        if not kwargs and len(args) == 1 and isinstance(args[0], dict):
             pairs = args[0]
         else:
             pairs = dict(*args, **kwargs)
@@ -397,7 +396,7 @@ class SortedDict(dict):
         assert all(key in self for key in self._list)
 
 
-class KeysView(AbstractKeysView, Set, Sequence):
+class KeysView(AbstractKeysView, Set, Sequence):    # pylint: disable=too-many-ancestors
     """
     A KeysView object is a dynamic view of the dictionary's keys, which
     means that when the dictionary's keys change, the view reflects
@@ -494,11 +493,11 @@ class KeysView(AbstractKeysView, Set, Sequence):
         """Return a SortedSet of the symmetric difference of self and *that*."""
         return SortedSet(self._view ^ that)
     if hexversion < 0x03000000:
-        def isdisjoint(self, that):
+        def isdisjoint(self, that):     # pylint: disable=arguments-differ
             """Return True if and only if *that* is disjoint with self."""
             return not any(key in self._list for key in that)
     else:
-        def isdisjoint(self, that):
+        def isdisjoint(self, that):     # pylint: disable=arguments-differ
             """Return True if and only if *that* is disjoint with self."""
             return self._view.isdisjoint(that)
     @recursive_repr
@@ -506,7 +505,7 @@ class KeysView(AbstractKeysView, Set, Sequence):
         return 'SortedDict_keys({0})'.format(repr(list(self)))
 
 
-class ValuesView(AbstractValuesView, Sequence):
+class ValuesView(AbstractValuesView, Sequence):  # pylint: disable=too-many-ancestors
     """
     A ValuesView object is a dynamic view of the dictionary's values, which
     means that when the dictionary's values change, the view reflects those
@@ -562,8 +561,7 @@ class ValuesView(AbstractValuesView, Sequence):
         _dict, _list = self._dict, self._list
         if isinstance(index, slice):
             return [_dict[key] for key in _list[index]]
-        else:
-            return _dict[_list[index]]
+        return _dict[_list[index]]
     def __reversed__(self):
         """
         Return a reverse iterator over the values in the dictionary.  Values are
@@ -574,7 +572,7 @@ class ValuesView(AbstractValuesView, Sequence):
         """
         _dict = self._dict
         return iter(_dict[key] for key in reversed(self._list))
-    def index(self, value):
+    def index(self, value):     # pylint: disable=arguments-differ
         """
         Return index of *value* in self.
 
@@ -613,7 +611,7 @@ class ValuesView(AbstractValuesView, Sequence):
         return 'SortedDict_values({0})'.format(repr(list(self)))
 
 
-class ItemsView(AbstractItemsView, Set, Sequence):
+class ItemsView(AbstractItemsView, Set, Sequence):  # pylint: disable=too-many-ancestors
     """
     An ItemsView object is a dynamic view of the dictionary's ``(key,
     value)`` pairs, which means that when the dictionary changes, the
@@ -667,9 +665,8 @@ class ItemsView(AbstractItemsView, Set, Sequence):
         _dict, _list = self._dict, self._list
         if isinstance(index, slice):
             return [(key, _dict[key]) for key in _list[index]]
-        else:
-            key = _list[index]
-            return (key, _dict[key])
+        key = _list[index]
+        return (key, _dict[key])
     def __reversed__(self):
         """
         Return a reversed iterable over the items in the dictionary. Items are
@@ -694,7 +691,7 @@ class ItemsView(AbstractItemsView, Set, Sequence):
             return pos
         else:
             raise ValueError('{0} is not in dict'.format(repr(key)))
-    def count(self, item):
+    def count(self, item):     # pylint: disable=arguments-differ
         """Return the number of occurrences of *item* in the set."""
         key, value = item
         return 1 if key in self._dict and self._dict[key] == value else 0
@@ -729,7 +726,7 @@ class ItemsView(AbstractItemsView, Set, Sequence):
         """Return a SortedSet of the symmetric difference of self and *that*."""
         return SortedSet(self._view ^ that)
     if hexversion < 0x03000000:
-        def isdisjoint(self, that):
+        def isdisjoint(self, that):     # pylint: disable=arguments-differ
             """Return True if and only if *that* is disjoint with self."""
             _dict = self._dict
             for key, value in that:
@@ -737,7 +734,7 @@ class ItemsView(AbstractItemsView, Set, Sequence):
                     return False
             return True
     else:
-        def isdisjoint(self, that):
+        def isdisjoint(self, that):     # pylint: disable=arguments-differ
             """Return True if and only if *that* is disjoint with self."""
             return self._view.isdisjoint(that)
     @recursive_repr

--- a/sortedcontainers/sortedlist.py
+++ b/sortedcontainers/sortedlist.py
@@ -15,8 +15,8 @@ from operator import iadd, add
 from sys import hexversion
 
 if hexversion < 0x03000000:
-    from itertools import izip as zip
-    from itertools import imap as map
+    from itertools import izip as zip   # pylint: disable=no-name-in-module
+    from itertools import imap as map   # pylint: disable=no-name-in-module
     try:
         from thread import get_ident
     except ImportError:
@@ -49,7 +49,7 @@ def recursive_repr(func):
 
     return wrapper
 
-class SortedList(MutableSequence):
+class SortedList(MutableSequence):  # pylint: disable=too-many-ancestors
     """
     SortedList provides most of the same methods as a list but keeps the items
     in sorted order.
@@ -237,7 +237,7 @@ class SortedList(MutableSequence):
         if _lists[pos][idx] == val:
             self._delete(pos, idx)
 
-    def remove(self, val):
+    def remove(self, val):     # pylint: disable=arguments-differ
         """
         Remove first occurrence of *val*.
 
@@ -874,13 +874,12 @@ class SortedList(MutableSequence):
                 chain.from_iterable(_lists[(min_pos + 1):max_pos]),
                 _lists[max_pos][:max_idx],
             )
-        else:
-            temp = map(reversed, reversed(_lists[(min_pos + 1):max_pos]))
-            return chain(
-                reversed(_lists[max_pos][:max_idx]),
-                chain.from_iterable(temp),
-                reversed(_lists[min_pos][min_idx:]),
-            )
+        temp = map(reversed, reversed(_lists[(min_pos + 1):max_pos]))
+        return chain(
+            reversed(_lists[max_pos][:max_idx]),
+            chain.from_iterable(temp),
+            reversed(_lists[min_pos][min_idx:]),
+        )
 
     def irange(self, minimum=None, maximum=None, inclusive=(True, True),
                reverse=False):
@@ -999,7 +998,7 @@ class SortedList(MutableSequence):
     bisect = bisect_right
     _bisect_right = bisect_right
 
-    def count(self, val):
+    def count(self, val):     # pylint: disable=arguments-differ
         """Return the number of occurrences of *val* in the list."""
         _maxes = self._maxes
 
@@ -1034,7 +1033,7 @@ class SortedList(MutableSequence):
 
     __copy__ = copy
 
-    def append(self, val):
+    def append(self, val):     # pylint: disable=arguments-differ
         """
         Append the element *val* to the list. Raises a ValueError if the *val*
         would violate the sort order.
@@ -1112,7 +1111,7 @@ class SortedList(MutableSequence):
 
         self._len += len(values)
 
-    def insert(self, idx, val):
+    def insert(self, idx, val):     # pylint: disable=arguments-differ
         """
         Insert the element *val* into the list at *idx*. Raises a ValueError if
         the *val* at *idx* would violate the sort order.
@@ -1174,7 +1173,7 @@ class SortedList(MutableSequence):
             msg = '{0} not in sort order at index {1}'.format(repr(val), idx)
             raise ValueError(msg)
 
-    def pop(self, idx=-1):
+    def pop(self, idx=-1):     # pylint: disable=arguments-differ
         """
         Remove and return item at *idx* (default last).  Raises IndexError if
         list is empty or index is out of range.  Negative indices are supported,
@@ -1369,7 +1368,7 @@ class SortedList(MutableSequence):
                 assert self._lists == []
                 return
 
-            assert len(self._maxes) > 0 and len(self._lists) > 0
+            assert self._maxes and self._lists
 
             # Check all sublists are sorted.
 
@@ -1407,7 +1406,7 @@ class SortedList(MutableSequence):
 
             # Check index.
 
-            if len(self._index):
+            if self._index:
                 assert len(self._index) == self._offset + len(self._lists)
                 assert self._len == self._index[0]
 
@@ -1451,7 +1450,7 @@ def identity(value):
     "Identity function."
     return value
 
-class SortedListWithKey(SortedList):
+class SortedListWithKey(SortedList):    # pylint: disable=too-many-ancestors
     """
     SortedListWithKey provides most of the same methods as a list but keeps
     the items in sorted order.
@@ -1881,7 +1880,7 @@ class SortedListWithKey(SortedList):
                 # isn't a Sequence, convert it to a tuple.
 
                 if not isinstance(value, Sequence):
-                    value = tuple(value) # pylint: disable=redefined-variable-type
+                    value = tuple(value)
 
                 # Check that the given values are ordered properly.
 
@@ -1893,7 +1892,7 @@ class SortedListWithKey(SortedList):
 
                 # Check ordering in context of sorted list.
 
-                if not start or not len(value):
+                if not start or not value:
                     # Nothing to check on the lhs.
                     pass
                 else:
@@ -1902,7 +1901,7 @@ class SortedListWithKey(SortedList):
                         msg = '{0} not in sort order at index {1}'.format(repr(value[0]), start)
                         raise ValueError(msg)
 
-                if stop == len(self) or not len(value):
+                if stop == len(self) or not value:
                     # Nothing to check on the rhs.
                     pass
                 else:
@@ -2396,7 +2395,7 @@ class SortedListWithKey(SortedList):
                 assert self._lists == []
                 return
 
-            assert len(self._maxes) > 0 and len(self._keys) > 0 and len(self._lists) > 0
+            assert self._maxes and self._keys and self._lists
 
             # Check all sublists are sorted.
 
@@ -2442,7 +2441,7 @@ class SortedListWithKey(SortedList):
 
             # Check index.
 
-            if len(self._index):
+            if self._index:
                 assert len(self._index) == self._offset + len(self._lists)
                 assert self._len == self._index[0]
 

--- a/sortedcontainers/sortedset.py
+++ b/sortedcontainers/sortedset.py
@@ -8,7 +8,7 @@ import operator as op
 
 from .sortedlist import SortedList, recursive_repr, SortedListWithKey
 
-class SortedSet(MutableSet, Sequence):
+class SortedSet(MutableSet, Sequence):  # pylint: disable=too-many-ancestors
     """
     A `SortedSet` provides the same methods as a `set`.  Additionally, a
     `SortedSet` maintains its items in sorted order, allowing the `SortedSet` to
@@ -37,7 +37,6 @@ class SortedSet(MutableSet, Sequence):
         on your usage.  It's best to leave the load factor at the default until
         you start benchmarking.
         """
-        # pylint: disable=redefined-variable-type
         self._key = key
         self._load = load
 
@@ -107,8 +106,7 @@ class SortedSet(MutableSet, Sequence):
                 return set_op(self._set, that._set)
             elif isinstance(that, Set):
                 return set_op(self._set, that)
-            else:
-                return NotImplemented
+            return NotImplemented
 
         comparer.__name__ = '__{0}__'.format(set_op.__name__)
         doc_str = 'Return True if and only if Set is {0} `that`.'


### PR DESCRIPTION
`d.clear()` showed up twice in the SortedDict API page.